### PR TITLE
feat(home): update help link to /scixhelp/

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -251,11 +251,7 @@ const Carousel = (props: { onExampleSelect: (text: string) => void }) => {
               </Text>
               <Text fontSize="xl">
                 Use the{' '}
-                <SimpleLink
-                  href="/scixhelp/quickstart-scix/searching-for-paper"
-                  anchorProps={{ display: 'inline' }}
-                  newTab
-                >
+                <SimpleLink href="/scixhelp/" anchorProps={{ display: 'inline' }} newTab>
                   quick start guide
                 </SimpleLink>{' '}
                 to start your search of the portal and find out where to go with any questions about advanced tools and


### PR DESCRIPTION
## Summary

Updates the help link on the home page from `/scixhelp/quickstart-scix/searching-for-paper` to `/scixhelp/` to provide better access to the main help documentation.

## Changes

- Changed the href in the "quick start guide" link in the home page carousel
- Link remains relative as requested
- Updated from specific quickstart page to main help section

## Testing

- [x] Local build passes
- [x] Link updated correctly in the home page
- [x] Link remains relative and opens in new tab as before

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update