### PR TITLE
Restore search results scroll position

### DIFF
--- a/src/components/ResultList/Item/Item.tsx
+++ b/src/components/ResultList/Item/Item.tsx
@@ -14,6 +14,7 @@ import {
 import { AllAuthorsModal } from '@/components/AllAuthorsModal';
 import { APP_DEFAULTS } from '@/config';
 import { useIsClient } from '@/lib/useIsClient';
+import { useScrollRestoration } from '@/lib/useScrollRestoration';
 import { useStore } from '@/store';
 import { MathJax } from 'better-react-mathjax';
 import dynamic from 'next/dynamic';
@@ -78,15 +79,26 @@ export const Item = (props: IItemProps): ReactElement => {
 
   const colors = useColorModeColors();
 
+  // Scroll restoration - save position when navigating to abstract
+  const { saveScrollPosition } = useScrollRestoration();
+
   // citations
   const cite = useNormCite ? (
     typeof doc.citation_count_norm === 'number' && doc.citation_count_norm > 0 ? (
-      <SimpleLink href={{ pathname: `/abs/${bibcode}/citations`, search: 'p=1' }} newTab={linkNewTab}>
+      <SimpleLink
+        href={{ pathname: `/abs/${bibcode}/citations`, search: 'p=1' }}
+        newTab={linkNewTab}
+        onClick={saveScrollPosition}
+      >
         <Text>cited(n): {doc.citation_count_norm.toFixed(2)}</Text>
       </SimpleLink>
     ) : null
   ) : typeof doc.citation_count === 'number' && doc.citation_count > 0 ? (
-    <SimpleLink href={{ pathname: `/abs/${bibcode}/citations`, search: 'p=1' }} newTab={linkNewTab}>
+    <SimpleLink
+      href={{ pathname: `/abs/${bibcode}/citations`, search: 'p=1' }}
+      newTab={linkNewTab}
+      onClick={saveScrollPosition}
+    >
       cited: {doc.citation_count}
     </SimpleLink>
   ) : null;
@@ -94,7 +106,11 @@ export const Item = (props: IItemProps): ReactElement => {
   // credited
   const credited =
     Array.isArray(doc.credit) && doc.credit.length > 0 ? (
-      <SimpleLink href={{ pathname: `/abs/${bibcode}/credits`, search: 'p=1' }} newTab={linkNewTab}>
+      <SimpleLink
+        href={{ pathname: `/abs/${bibcode}/credits`, search: 'p=1' }}
+        newTab={linkNewTab}
+        onClick={saveScrollPosition}
+      >
         credited: {doc.credit.length}
       </SimpleLink>
     ) : null;
@@ -124,7 +140,12 @@ export const Item = (props: IItemProps): ReactElement => {
       </Flex>
       <Stack direction="column" width="full" spacing={0} mx={3} mt={2}>
         <Flex justifyContent="space-between" minH="40px">
-          <SimpleLink href={`/abs/${bibcode}/abstract`} fontWeight="semibold" className="article-title">
+          <SimpleLink
+            href={`/abs/${bibcode}/abstract`}
+            fontWeight="semibold"
+            className="article-title"
+            onClick={saveScrollPosition}
+          >
             <Text as={MathJax} dangerouslySetInnerHTML={{ __html: unwrapStringValue(title) }} />
           </SimpleLink>
           <Flex alignItems="start" ml={1}>

--- a/src/components/SimpleLink/SimpleLink.tsx
+++ b/src/components/SimpleLink/SimpleLink.tsx
@@ -37,7 +37,6 @@ export const SimpleLink = forwardRef(
         href={href}
         prefetch={prefetch}
         passHref={passHref}
-        onClick={onClick}
         onTouchStart={onTouchStart}
         onMouseEnter={onMouseEnter}
         onNavigate={onNavigate}
@@ -50,6 +49,7 @@ export const SimpleLink = forwardRef(
       >
         <chakra.a
           ref={ref}
+          onClick={onClick}
           target={newTab || isExternal ? '_blank' : undefined}
           rel={isExternal ? 'noopener' : undefined}
           {...rest}

--- a/src/lib/useScrollRestoration.ts
+++ b/src/lib/useScrollRestoration.ts
@@ -1,0 +1,68 @@
+import { useRouter } from 'next/router';
+import { useEffect, useRef } from 'react';
+import { logger } from '@/logger';
+
+const SCROLL_POSITION_KEY = 'search-scroll-position';
+
+/**
+ * Hook to manage scroll position restoration when navigating between search results and abstract pages
+ */
+export const useScrollRestoration = () => {
+  const router = useRouter();
+  const shouldRestoreRef = useRef(false);
+
+  useEffect(() => {
+    // Only run on client side
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    // Check if we should restore scroll position on mount
+    const savedPosition = sessionStorage.getItem(SCROLL_POSITION_KEY);
+    logger.debug({ savedPosition }, 'useScrollRestoration');
+    if (savedPosition && router.pathname === '/search') {
+      shouldRestoreRef.current = true;
+
+      // Use requestAnimationFrame to ensure DOM is ready
+      requestAnimationFrame(() => {
+        const position = parseInt(savedPosition, 10);
+        if (!isNaN(position)) {
+          window.scrollTo({
+            top: position,
+            // Use 'auto' for instant scroll, 'smooth' for animated
+            behavior: 'auto',
+          });
+        }
+        // Clear the stored position after restoration
+        sessionStorage.removeItem(SCROLL_POSITION_KEY);
+        shouldRestoreRef.current = false;
+      });
+    }
+  }, [router.pathname]);
+
+  /**
+   * Save current scroll position to sessionStorage
+   * Call this before navigating away from the search page
+   */
+  const saveScrollPosition = () => {
+    if (typeof window !== 'undefined' && router.pathname === '/search') {
+      const scrollPosition = window.scrollY || window.pageYOffset || document.documentElement.scrollTop;
+      sessionStorage.setItem(SCROLL_POSITION_KEY, scrollPosition.toString());
+    }
+  };
+
+  /**
+   * Clear saved scroll position
+   * Useful if you want to prevent restoration in certain cases
+   */
+  const clearScrollPosition = () => {
+    if (typeof window !== 'undefined') {
+      sessionStorage.removeItem(SCROLL_POSITION_KEY);
+    }
+  };
+
+  return {
+    saveScrollPosition,
+    clearScrollPosition,
+  };
+};

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -36,6 +36,7 @@ import {
 import { calculateStartIndex } from '@/components/ResultList/Pagination/usePagination';
 import { FormEventHandler, RefObject, useEffect, useRef, useState } from 'react';
 import { useIsClient } from '@/lib/useIsClient';
+import { useScrollRestoration } from '@/lib/useScrollRestoration';
 import { NumPerPageType } from '@/types';
 import Head from 'next/head';
 import { BRAND_NAME_FULL } from '@/config';
@@ -123,6 +124,9 @@ const SearchPage: NextPage = () => {
   const { data, isSuccess, isLoading, isFetching, error, isError } = useSearch(searchParams);
   const histogramContainerRef = useRef<HTMLDivElement>(null);
   const isClient = useIsClient();
+
+  // Scroll restoration hook - automatically restores scroll position when returning from abstract page
+  useScrollRestoration();
 
   const { isOpen: isAddToLibraryOpen, onClose: onCloseAddToLibrary, onOpen: onOpenAddToLibrary } = useDisclosure();
 


### PR DESCRIPTION
- add hook to store/restore scroll position on search page
- wire result, citation, and credits links to save position before navigation
- ensure SimpleLink onClick runs on the anchor so callbacks fire
- testing: not run (not requested)
