### PR TITLE
SCIX-876 Change UAT facet to use uat field instead of uat_facet_hier

### DIFF
--- a/src/api/search/types.ts
+++ b/src/api/search/types.ts
@@ -123,6 +123,7 @@ export type FacetField =
   | 'nedtype_object_facet_hier'
   | 'simbad_object_facet_hier'
   | 'planetary_feature_facet_hier_3level'
+  | 'uat'
   | 'uat_facet_hier';
 
 export interface IFacetCountsFields {

--- a/src/components/SearchFacet/config.ts
+++ b/src/components/SearchFacet/config.ts
@@ -131,14 +131,11 @@ export const facetConfig: Record<SearchFacetID, Omit<ISearchFacetProps, 'onQuery
   },
   uat: {
     label: 'UAT',
-    field: 'uat_facet_hier' as FacetField,
+    field: 'uat' as FacetField,
     hasChildren: false,
-    // UAT needs hierarchical API prefixing (0/) but has no expandable children
-    forceHierarchicalPrefix: true,
-    maxDepth: 1,
     logic: defaultLogic,
     storeId: 'uat',
     noLoadMore: true,
-    isLowerCase: true,
+    isLowerCase: false,
   },
 };

--- a/src/components/SearchFacet/helpers.ts
+++ b/src/components/SearchFacet/helpers.ts
@@ -127,7 +127,7 @@ export const cleanClause = curry((fqKey: string, clause: string) => {
   const operator = getOperator(clause);
 
   // for hierarchical facets, there is more processing to make it get the fields
-  if (fqKey === 'fq_author' || fqKey === 'fq_planetary_feature' || fqKey === 'fq_uat') {
+  if (fqKey === 'fq_author' || fqKey === 'fq_planetary_feature') {
     return pipe(
       map(pipe(replace(/["\\]/g, ''), parseTitleFromKey)),
 

--- a/src/components/SearchFacet/types.ts
+++ b/src/components/SearchFacet/types.ts
@@ -50,7 +50,7 @@ export const facetFields: FacetField[] = [
   'nedtype_object_facet_hier',
   'simbad_object_facet_hier',
   'planetary_feature_facet_hier_3level',
-  'uat_facet_hier',
+  'uat',
 ];
 
 export type SearchFacetID =

--- a/src/components/__mocks__/facetCountFields.ts
+++ b/src/components/__mocks__/facetCountFields.ts
@@ -20,6 +20,7 @@ export const facetFoundFieldsData: IFacetCountsFields = {
     property: [],
     simbad_object_facet_hier: [],
     planetary_feature_facet_hier_3level: [],
+    uat: [],
     uat_facet_hier: [],
   },
   facet_ranges: {},

--- a/src/mocks/generators/facets.ts
+++ b/src/mocks/generators/facets.ts
@@ -20,8 +20,8 @@ const createVal = (prefix: string, id: FacetField) => {
     case 'ned_object_facet_hier':
     case 'planetary_feature_facet_hier_3level':
       return `${prefix}${faker.lorem.words(2)}`;
-    case 'uat_facet_hier':
-      return `${prefix}${faker.lorem.words(2)}`;
+    case 'uat':
+      return faker.lorem.words(2);
 
     default:
       return `${faker.lorem.words(3)}`;


### PR DESCRIPTION
Changes the UAT search facet to query the uat field instead of uat_facet_hier.

- Updated UAT facet config to use the flat uat field (removed hierarchical prefixing)
- Added uat to the FacetField type and facet field list
- Removed fq_uat from the hierarchical cleanClause branch
- Updated facet mocks for the uat field