### PR TITLE
feat(landing): add What's New widget fed by RSS/Atom feed

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -44,6 +44,10 @@ const nextConfig = {
           source: '/link_gateway/:path*',
           destination: `${process.env.BASE_CANONICAL_URL}/link_gateway/:path*`,
         });
+        beforeFiles.push({
+          source: '/scixblog/:path*',
+          destination: `${process.env.BASE_CANONICAL_URL}/scixblog/:path*`,
+        });
       }
 
       if (process.env.API_HOST_CLIENT) {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "downshift": "^6.1.7",
     "escape-html": "^1.0.3",
     "express": "^5.2.1",
+    "fast-xml-parser": "^5.9.2",
     "file-saver": "^2.0.5",
     "framer-motion": "^6.5.1",
     "fuse.js": "^6.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      fast-xml-parser:
+        specifier: ^5.9.2
+        version: 5.9.2
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -1433,6 +1436,9 @@ packages:
     peerDependencies:
       '@nivo/core': 0.80.0
       react: '>= 16.14.0 < 19.0.0'
+
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2921,6 +2927,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -4004,6 +4013,13 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.9.2:
+    resolution: {integrity: sha512-DYPkXnVSJHAGAkSBeVYhEo/seIpz2SLr9OQcX7m6lXaX3gvoB+DCKzFdZIEhZGI3I1DUhObBAUOT/v2xfoXz/w==}
+    hasBin: true
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -4561,6 +4577,9 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-unsafe@1.0.1:
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -5120,6 +5139,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -5863,6 +5886,9 @@ packages:
   strip-literal@1.3.0:
     resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
 
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
   style-value-types@5.0.0:
     resolution: {integrity: sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==}
 
@@ -6422,6 +6448,10 @@ packages:
 
   xml-name-validator@3.0.0:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -7592,6 +7622,8 @@ snapshots:
       d3-delaunay: 5.3.0
       d3-scale: 3.3.0
       react: 18.3.1
+
+  '@nodable/entities@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -9238,6 +9270,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  anynum@1.0.1: {}
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -10302,7 +10336,7 @@ snapshots:
       eslint: 9.32.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint@9.32.0))(eslint@9.32.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint@9.32.0))(eslint@9.32.0))(eslint@9.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.32.0)
       eslint-plugin-react: 7.37.5(eslint@9.32.0)
       eslint-plugin-react-hooks: 7.0.1(eslint@9.32.0)
@@ -10335,7 +10369,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint@9.32.0))(eslint@9.32.0))(eslint@9.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10350,7 +10384,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.32.0)(typescript@5.9.3))(eslint@9.32.0))(eslint@9.32.0))(eslint@9.32.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10610,6 +10644,20 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.9.2:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      is-unsafe: 1.0.1
+      path-expression-matcher: 1.5.0
+      strnum: 2.4.1
+      xml-naming: 0.1.0
 
   fastq@1.19.1:
     dependencies:
@@ -11188,6 +11236,8 @@ snapshots:
       which-typed-array: 1.1.19
 
   is-unicode-supported@0.1.0: {}
+
+  is-unsafe@1.0.1: {}
 
   is-weakmap@2.0.2: {}
 
@@ -11814,6 +11864,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -12719,6 +12771,10 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
   style-value-types@5.0.0:
     dependencies:
       hey-listen: 1.0.8
@@ -13334,6 +13390,8 @@ snapshots:
   ws@7.5.10: {}
 
   xml-name-validator@3.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xmlchars@2.2.0: {}
 

--- a/src/components/WhatsNewWidget/WhatsNewWidget.test.tsx
+++ b/src/components/WhatsNewWidget/WhatsNewWidget.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@/test-utils';
+import { describe, test, expect } from 'vitest';
+import { rest } from 'msw';
+import { server } from '@/mocks/server';
+import { WhatsNewWidget, WidgetRow } from './WhatsNewWidget';
+
+const mockItems = [
+  {
+    title: 'New search filters added',
+    link: '/scixblog/new-search-filters',
+    pubDate: 'Mon, 01 Jun 2026 00:00:00 +0000',
+    summary: 'We added faceted search filters for date range and author affiliation.',
+  },
+  {
+    title: 'Performance improvements',
+    link: '/scixblog/performance-improvements',
+    pubDate: 'Thu, 15 May 2026 00:00:00 +0000',
+    summary: '',
+  },
+];
+
+const feedHandler = (items: typeof mockItems) =>
+  rest.get('/api/whats-new', (req, res, ctx) => res(ctx.json({ items })));
+
+const errorHandler = () => rest.get('/api/whats-new', (req, res, ctx) => res(ctx.status(500)));
+
+describe('WhatsNewWidget', () => {
+  test('renders heading', async () => {
+    server.use(feedHandler(mockItems));
+    render(<WhatsNewWidget />);
+    expect(screen.getByRole('heading', { name: "What's New" })).toBeInTheDocument();
+  });
+
+  test('shows feed items after load', async () => {
+    server.use(feedHandler(mockItems));
+    render(<WhatsNewWidget />);
+
+    await waitFor(() => {
+      expect(screen.getByText('New search filters added')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Performance improvements')).toBeInTheDocument();
+    expect(screen.getByText('Jun 1, 2026')).toBeInTheDocument();
+    expect(screen.getByText('May 15, 2026')).toBeInTheDocument();
+  });
+
+  test('shows summary text when present', async () => {
+    server.use(feedHandler(mockItems));
+    render(<WhatsNewWidget />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('We added faceted search filters for date range and author affiliation.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('items render as external links', async () => {
+    server.use(feedHandler(mockItems));
+    render(<WhatsNewWidget />);
+
+    const link = await screen.findByRole('link', { name: /New search filters added/i });
+    expect(link).toHaveAttribute('href', '/scixblog/new-search-filters');
+  });
+
+  test('shows empty state on server error', async () => {
+    server.use(errorHandler());
+    render(<WhatsNewWidget />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No updates available.')).toBeInTheDocument();
+    });
+  });
+
+  test('shows empty state when items array is empty', async () => {
+    server.use(feedHandler([]));
+    render(<WhatsNewWidget />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No updates available.')).toBeInTheDocument();
+    });
+  });
+
+  test('loading state shows aria-busy container', () => {
+    server.use(rest.get('/api/whats-new', (req, res, ctx) => res(ctx.delay('infinite'), ctx.json({ items: [] }))));
+    render(<WhatsNewWidget />);
+    expect(screen.getByLabelText('Loading updates')).toBeInTheDocument();
+  });
+});
+
+describe('WidgetRow', () => {
+  test('renders children', () => {
+    render(
+      <WidgetRow>
+        <div data-testid="child">widget</div>
+      </WidgetRow>,
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});

--- a/src/components/WhatsNewWidget/WhatsNewWidget.tsx
+++ b/src/components/WhatsNewWidget/WhatsNewWidget.tsx
@@ -1,0 +1,113 @@
+import { Box, Flex, Heading, Link, Skeleton, Stack, StackDivider, Text } from '@chakra-ui/react';
+import { useQuery } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useColorModeColors } from '@/lib/useColorModeColors';
+import type { WhatsNewItem, WhatsNewResponse } from '@/pages/api/whats-new';
+
+const BLOG_URL = 'https://scixplorer.org/scixblog/';
+const ITEM_COUNT = 5;
+const STALE_MS = 60 * 60 * 1000;
+
+const fetchFeed = async (): Promise<WhatsNewResponse> => {
+  const res = await fetch('/api/whats-new');
+  if (!res.ok) {
+    throw new Error('feed unavailable');
+  }
+  return res.json() as Promise<WhatsNewResponse>;
+};
+
+const formatDate = (raw: string): string => {
+  if (!raw) {
+    return '';
+  }
+  const d = new Date(raw);
+  if (isNaN(d.getTime())) {
+    return '';
+  }
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+};
+
+interface FeedItemProps {
+  item: WhatsNewItem;
+  linkColor: string;
+  subtextColor: string;
+}
+
+const FeedItem = ({ item, linkColor, subtextColor }: FeedItemProps) => (
+  <Box py={1}>
+    <Link
+      href={item.link}
+      color={linkColor}
+      fontWeight="semibold"
+      fontSize="sm"
+      lineHeight="short"
+      display="block"
+      _hover={{ textDecoration: 'underline' }}
+    >
+      <Text noOfLines={2} title={item.title}>
+        {item.title}
+      </Text>
+    </Link>
+    {item.summary && (
+      <Text fontSize="xs" color={subtextColor} mt={1} noOfLines={2}>
+        {item.summary}
+      </Text>
+    )}
+    {item.pubDate && (
+      <Text fontSize="xs" color={subtextColor} mt={1}>
+        {formatDate(item.pubDate)}
+      </Text>
+    )}
+  </Box>
+);
+
+export const WidgetRow = ({ children }: { children: ReactNode }) => (
+  <Flex direction={{ base: 'column', md: 'row' }} gap={4} w="87%" mt={6} alignItems="flex-start">
+    {children}
+  </Flex>
+);
+
+export const WhatsNewWidget = () => {
+  const colors = useColorModeColors();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['whats-new'],
+    queryFn: fetchFeed,
+    staleTime: STALE_MS,
+    retry: false,
+  });
+
+  const items = data?.items ?? [];
+
+  return (
+    <Box borderWidth={1} borderRadius="md" p={4} bg="transparent" borderColor={colors.border} w="full">
+      <Heading as="h3" size="sm" mb={3} color={colors.text}>
+        What&#39;s New
+      </Heading>
+
+      {isLoading ? (
+        <Stack spacing={3} aria-busy="true" aria-label="Loading updates">
+          {Array.from({ length: ITEM_COUNT }).map((_, i) => (
+            <Skeleton key={i} height="40px" borderRadius={4} />
+          ))}
+        </Stack>
+      ) : isError || items.length === 0 ? (
+        <Text fontSize="sm" color={colors.lightText}>
+          No updates available.
+        </Text>
+      ) : (
+        <Stack spacing={0} divider={<StackDivider borderColor={colors.border} />}>
+          {items.map((item, i) => (
+            <FeedItem key={i} item={item} linkColor={colors.link} subtextColor={colors.lightText} />
+          ))}
+          <StackDivider borderColor={colors.border} />
+        </Stack>
+      )}
+
+      {!isLoading && (
+        <Link href={BLOG_URL} isExternal fontSize="sm" color={colors.link} display="block" mt={3}>
+          See more
+        </Link>
+      )}
+    </Box>
+  );
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,7 @@ export const ORCID_BULK_DELETE_CHUNK_SIZE = 4;
 export const ORCID_BULK_DELETE_DELAY = 1000;
 export const SCIX_CANONICAL_BASE_URL = 'https://scixplorer.org';
 export const ADS_CANONICAL_BASE_URL = 'https://ui.adsabs.harvard.edu';
+export const WHATS_NEW_FEED_URL = `${SCIX_CANONICAL_BASE_URL}/help/common/feed.xml`;
 
 export const EXTERNAL_URLS = {
   USGS_PLANETARY_FEATURES: 'https://planetarynames.wr.usgs.gov/Feature/' as const,

--- a/src/pages/api/whats-new.ts
+++ b/src/pages/api/whats-new.ts
@@ -1,0 +1,155 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { XMLParser } from 'fast-xml-parser';
+import { WHATS_NEW_FEED_URL } from '@/config';
+
+export interface WhatsNewItem {
+  title: string;
+  link: string;
+  pubDate: string;
+  summary: string;
+}
+
+export interface WhatsNewResponse {
+  items: WhatsNewItem[];
+}
+
+const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_' });
+const ITEM_LIMIT = 5;
+const FETCH_TIMEOUT_MS = 5000;
+
+const toStr = (v: unknown): string => (v == null ? '' : String(v).trim());
+
+const extractTitle = (title: unknown): string => {
+  if (!title) {
+    return '';
+  }
+  if (typeof title === 'string') {
+    return title.trim();
+  }
+  if (typeof title === 'object' && title !== null) {
+    const obj = title as Record<string, unknown>;
+    return toStr(obj['#text'] ?? obj['_text'] ?? '');
+  }
+  return '';
+};
+
+// Atom link is an object or array of objects with @_href; RSS link is a plain string.
+const extractLink = (link: unknown, fallback = ''): string => {
+  if (!link) {
+    return fallback;
+  }
+  if (typeof link === 'string') {
+    return link.trim() || fallback;
+  }
+  if (Array.isArray(link)) {
+    const alt =
+      link.find(
+        (l) => typeof l === 'object' && l !== null && (l as Record<string, unknown>)['@_rel'] === 'alternate',
+      ) ?? link[0];
+    return extractLink(alt, fallback);
+  }
+  if (typeof link === 'object' && link !== null) {
+    return toStr((link as Record<string, unknown>)['@_href']) || fallback;
+  }
+  return fallback;
+};
+
+const stripHtml = (html: string): string =>
+  html
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const extractText = (v: unknown): string => {
+  if (!v) {
+    return '';
+  }
+  if (typeof v === 'string') {
+    return stripHtml(v);
+  }
+  if (typeof v === 'object' && v !== null) {
+    const obj = v as Record<string, unknown>;
+    return stripHtml(toStr(obj['#text'] ?? obj['_text'] ?? ''));
+  }
+  return '';
+};
+
+const rewriteItemUrl = (url: string): string => {
+  if (url.startsWith('/blog/')) {
+    return '/scixblog/' + url.slice('/blog/'.length);
+  }
+  if (url.startsWith('/')) {
+    return url;
+  }
+  try {
+    const parsed = new URL(url);
+    const path = parsed.pathname.replace(/^\/blog\//, '/scixblog/');
+    return path + parsed.search + parsed.hash;
+  } catch {
+    return url;
+  }
+};
+
+const toRawArray = (v: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(v)) {
+    return v as Record<string, unknown>[];
+  }
+  if (v && typeof v === 'object') {
+    return [v as Record<string, unknown>];
+  }
+  return [];
+};
+
+const extractItems = (parsed: Record<string, unknown>): WhatsNewItem[] => {
+  const rss = parsed?.rss as Record<string, unknown> | undefined;
+
+  // RSS 2.0
+  if (rss?.channel) {
+    const channel = rss.channel as Record<string, unknown>;
+    return toRawArray(channel.item)
+      .slice(0, ITEM_LIMIT)
+      .map((item) => ({
+        title: extractTitle(item.title),
+        link: rewriteItemUrl(extractLink(item.link, toStr(item.guid))),
+        pubDate: toStr(item.pubDate ?? item.published),
+        summary: extractText(item.description ?? item.summary),
+      }));
+  }
+
+  // Atom
+  const feed = parsed?.feed as Record<string, unknown> | undefined;
+  if (feed) {
+    return toRawArray(feed.entry)
+      .slice(0, ITEM_LIMIT)
+      .map((item) => ({
+        title: extractTitle(item.title),
+        link: rewriteItemUrl(extractLink(item.link, toStr(item.id))),
+        pubDate: toStr(item.published ?? item.updated),
+        summary: extractText(item.summary ?? item.content),
+      }));
+  }
+
+  return [];
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<WhatsNewResponse>) {
+  try {
+    const feedRes = await fetch(WHATS_NEW_FEED_URL, {
+      headers: { Accept: 'application/rss+xml, application/xml, text/xml' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+
+    if (!feedRes.ok) {
+      return res.status(200).json({ items: [] });
+    }
+
+    const xml = await feedRes.text();
+    const parsed = parser.parse(xml) as Record<string, unknown>;
+    const items = extractItems(parsed);
+
+    res.setHeader('Cache-Control', 's-maxage=3600, stale-while-revalidate');
+    return res.status(200).json({ items });
+  } catch {
+    return res.status(200).json({ items: [] });
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,6 +32,7 @@ import { makeSearchParams, normalizeSolrSort } from '@/utils/common/search';
 import { SolrSort } from '@/api/models';
 import { SearchExamples } from '@/components/SearchExamples/SearchExamples';
 import { Pager } from '@/components/Pager/Pager';
+import { WidgetRow, WhatsNewWidget } from '@/components/WhatsNewWidget/WhatsNewWidget';
 import {
   ChatBubbleBottomCenterIcon,
   DocumentIcon,
@@ -194,6 +195,9 @@ const HomePage: NextPage = () => {
       </form>
       <Stats />
       <IntroVideoSection />
+      <WidgetRow>
+        <WhatsNewWidget />
+      </WidgetRow>
       <FloatingIntroLink />
     </Flex>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "noUncheckedIndexedAccess": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,6 +7,11 @@ export default defineConfig({
   plugins: [...react(), tsconfigPaths()],
   test: {
     environment: 'jsdom',
+    environmentOptions: {
+      jsdom: {
+        url: 'http://localhost:3000',
+      },
+    },
     exclude: [...defaultExclude, '**/e2e/**', '**/.worktrees/**'],
     setupFiles: ['./vitest-setup.ts'],
     isolate: true,


### PR DESCRIPTION
Landing page had no dynamic content surface. Adds a compact widget below the intro video that fetches from the SciX help blog feed and renders the 5 most recent items with title, summary, and date.

- /api/whats-new: server-side fetch + fast-xml-parser, handles RSS 2.0 and Atom, strips HTML from summaries, rewrites item URLs to relative /scixblog/ paths
- WhatsNewWidget: React Query fetch, skeleton loading, empty/error state, "See more" link persists in all non-loading states
- WidgetRow flex wrapper on landing page for future widget slots
- Feed URL hard-coded from SCIX_CANONICAL_BASE_URL + /help/common/feed.xml
- next.config.mjs: proxy /scixblog/* to canonical URL
- vitest.config.js: set jsdom url so relative fetch calls resolve in tests